### PR TITLE
Fix for first two beeps being run at same time

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,6 @@ module.exports = function (val) {
 	if (val == null) {
 		beep();
 	} else if (typeof val === 'number') {
-		beep();
-		val--;
-
 		while (val--) {
 			setTimeout(beep, BEEP_DELAY * val);
 		}


### PR DESCRIPTION
This fixes calls to `beeper(x)` when `x` (`val`) is `> 1`.

To demonstrate how the existing implementation has a bug, change `BEEP_DELAY` to `3000`, change the `beep()` function to log the current time (see snippet below), and call `beeper(3)`. You'll see that the first two beeps execute at the same time (meaning that `beeper(3)` only beeps twice).

    function beep() {
        console.log('beep ' + new Date());
        process.stdout.write('\u0007');
    }

The proposed change fixes this bug.