### PR TITLE
Wrap guard if with IIFE

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
 
 var BEEP_DELAY = 500;
 
-if (!process.stdout.isTTY ||
-	process.argv.indexOf('--no-beep') !== -1 ||
-	process.argv.indexOf('--beep=false') !== -1) {
-	module.exports = function () {};
-	return;
-}
+(function() {
+	if (!process.stdout.isTTY ||
+		process.argv.indexOf('--no-beep') !== -1 ||
+		process.argv.indexOf('--beep=false') !== -1) {
+		module.exports = function () {};
+		return;
+	}
+})();
 
 function beep() {
 	process.stdout.write('\u0007');


### PR DESCRIPTION
When using beeper with NPM and Webpack one may face issue with "illegal return statement"  #(webpack/webpack/issues/67).
The solution is to use IIFE for the guard statement.